### PR TITLE
Banner + Simulator Sorting Updated

### DIFF
--- a/app/_custom/routes/$siteId.collections+/banners.tsx
+++ b/app/_custom/routes/$siteId.collections+/banners.tsx
@@ -66,7 +66,11 @@ export async function loader({
 
    // Sort banners by banner_id
    data.Banners.docs.sort((a: any, b: any) =>
-      a.banner_id > b.banner_id ? -1 : b.banner_id > a.banner_id ? 1 : 0
+      parseInt(a.banner_id) > parseInt(b.banner_id)
+         ? -1
+         : parseInt(b.banner_id) > parseInt(a.banner_id)
+         ? 1
+         : 0
    );
 
    return json({ banners: data.Banners.docs });

--- a/app/_custom/routes/$siteId.simulator.tsx
+++ b/app/_custom/routes/$siteId.simulator.tsx
@@ -55,6 +55,15 @@ export const meta: V2_MetaFunction = () => {
 const SummonSimulator = (data: any) => {
    //need banners, weapons, characters
    const { banners, characters, lightCones } = useLoaderData<typeof loader>();
+
+   // Resort banner by ID numeric
+   banners.sort((a: any, b: any) =>
+      parseInt(a.banner_id) > parseInt(b.banner_id)
+         ? 1
+         : parseInt(b.banner_id) > parseInt(a.banner_id)
+         ? -1
+         : 0
+   );
    /*
       ========================================================================
       STATE VARIABLES


### PR DESCRIPTION
- Fixed sorting to handle IDs as numbers rather than strings.

Affected pages:
- Banner List (/starrail/collections/banners)
- Simulator (/starrail/simulator)